### PR TITLE
Fix matcher for future parser.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -25,10 +25,10 @@ class shibboleth::params {
   $discovery_protocol = 'SAMLDS'
 
   case $::osfamily {
-    Debian:{
+    'Debian':{
       # Do nothing
     }
-    RedHat:{
+    'RedHat':{
       # Do nothing
     }
     default:{


### PR DESCRIPTION
In the future parser (`--parser future`), an unquoted value starting with an uppercase like `RedHat` is treated as a Type value, which then doesn't match the fact so it falls through to the fail(). Need to quote them so they continue to get matched as strings in the future.