### PR TITLE
Ensure metadata cert and Auegeas resources depend on shibboleth conf

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,7 +52,9 @@ class shibboleth (
     path    => $config_file,
     replace => false,
     require => [Class['apache::mod::shib'],File['shibboleth_conf_dir']],
-  }
+  } 
+
+  File['shibboleth_config_file'] -> Augeas <| incl == $config_file |>
 
 # Using augeas is a performance hit, but it works. Fix later.
   augeas{'sp_config_resources':

--- a/manifests/metadata.pp
+++ b/manifests/metadata.pp
@@ -20,6 +20,7 @@ define shibboleth::metadata(
     path    => ['/usr/bin'],
     command => "wget ${cert_uri} -O ${cert_file}",
     creates => $cert_file,
+    require => File['shibboleth_conf_dir'],
     notify  => Service['httpd','shibd'],
   }
 


### PR DESCRIPTION
Metadata cert download and augeas resources fail on the first puppet run with the module because the shibboleth config dir doesn't exist yet (package not yet installed).  