### PR TITLE
attribute_map: Ensure that attribute_map is not always downloaded

### DIFF
--- a/manifests/attribute_map.pp
+++ b/manifests/attribute_map.pp
@@ -12,7 +12,7 @@ define shibboleth::attribute_map(
   exec{"get_${name}_attribute_map":
     path    => ['/usr/bin'],
     command => "wget ${map_uri} -O ${attribute_map}",
-    unless  => "test `find ${attribute_map} -mtime +${max_age}`",
+    unless  => "test `find ${attribute_map} -mtime -${max_age}`",
     notify  => Service['httpd','shibd'],
   }
 

--- a/manifests/attribute_map.pp
+++ b/manifests/attribute_map.pp
@@ -12,7 +12,7 @@ define shibboleth::attribute_map(
   exec{"get_${name}_attribute_map":
     path    => ['/usr/bin'],
     command => "wget ${map_uri} -O ${attribute_map}",
-    unless  => "test `find ${attribute_map} -mtime -${max_age}`",
+    unless  => "test `find ${attribute_map} -ctime -${max_age}`",
     notify  => Service['httpd','shibd'],
   }
 


### PR DESCRIPTION
Due to a sign error in the unless statement the attribute_map was
downloaded on every Puppet run. This patch makes sure that max_age is
respected.