### PR TITLE
Replace inline templates with modern Puppet functions

### DIFF
--- a/manifests/metadata.pp
+++ b/manifests/metadata.pp
@@ -4,9 +4,9 @@ define shibboleth::metadata(
   $provider_uri,
   $cert_uri,
   $backing_file_dir         = $::shibboleth::conf_dir,
-  $backing_file_name        = inline_template("<%= @provider_uri.split('/').last  %>"),
+  $backing_file_name        = $provider_uri.split('/')[-1],
   $cert_dir                 = $::shibboleth::conf_dir,
-  $cert_file_name           = inline_template("<%= @cert_uri.split('/').last  %>"),
+  $cert_file_name           = $cert_uri.split('/')[-1],
   $provider_type            = 'XML',
   $provider_reload_interval = '7200',
   $metadata_filter_max_validity_interval  = '2419200'


### PR DESCRIPTION
This code change avoids errors of the following kind (at least for
modern Puppet versions):
"Failed to parse inline template: undefined method `split' for nil:NilClass"