### PR TITLE
sso: Make discoveryProtocol attribute removable

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ The `shibboleth` module provides the following classes and resource definitions:
 ### Prameters for `shibboleth::sso`
 * `discoveryURL`        The URL of the discovery service, is undefined by default
 * `idpURL`              The URL of a single IDp, is undefined by default
-* `discovery_protocol`  Sets the discovery protocol for the discovery service provided in the `discoveryURL`, defaults to "SAMLDS",
+* `discovery_protocol`  Sets the discovery protocol for the discovery service provided in the `discoveryURL`, defaults to "SAMLDS"; if set to "none", discoveryProtocol attribute is removed
 * `ecp_support`         Sets support for non-web based ECP logins, by default this is `false`
 
 **Note:** Either one of `discoveryURL` or `idpURL` is required, but not both.

--- a/manifests/sso.pp
+++ b/manifests/sso.pp
@@ -18,6 +18,12 @@ define shibboleth::sso (
       $entityID_aug = 'rm SSO/#attribute/entityID'
     }
 
+    if $discovery_protocol == 'none' {
+      $discovery_protocol_aug = 'rm SSO/#attribute/discoveryProtocol'
+    } else {
+      $discovery_protocol_aug = "set SSO/#attribute/discoveryProtocol ${discovery_protocol}"
+    }
+
     if $discoveryURL {
       $discoveryURL_aug = "set SSO/#attribute/discoveryURL ${discoveryURL}"
     } else {
@@ -31,7 +37,7 @@ define shibboleth::sso (
       changes => [
         $entityID_aug,
         $discoveryURL_aug,
-        "set SSO/#attribute/discoveryProtocol ${discovery_protocol}",
+        $discovery_protocol_aug,
         "set SSO/#attribute/ECP ${ecp_support}",
       ],
       notify  => Service['httpd','shibd'],


### PR DESCRIPTION
Setting a discoveryProtocol if a single IdP is used leads to the
following error:

"ERROR Shibboleth.Application : SSO discoveryProtocol specified without
discoveryURL"

Therefore the discoveryProtocol attribute has to be removable. Overriding
the default parameter $::shibboleth::params::discovery_protocol with undef
and applying a similar logic as for $discoveryURL and $idpURL does not
work. The reason is explained in

https://tickets.puppetlabs.com/browse/PUP-5295

"The semantics of giving undef as an argument to a resource (class or
other) is that the result is the default value of that parameter."

For this reason the value "none" was introduced for the
$discovery_protocol parameter to indicate removal of this attribute.